### PR TITLE
Update braintree dependency to fix Xcode 8.3.2 issues

### DIFF
--- a/ASPayPalPayments.podspec
+++ b/ASPayPalPayments.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
 	s.ios.deployment_target = '8.0'
 	s.requires_arc = true
 	s.source_files = 'iOS/PayPal-Payments/*.{h,m}'
-	s.dependency 'Braintree/PayPal', '~>4.7.1'
+	s.dependency 'Braintree/PayPal', '~>4.8.1'
 
 end


### PR DESCRIPTION
Update braintree to 4.8.1